### PR TITLE
Description: Porting alibi implementation from https://github.com/NVIDIA/Megatron-LM/pull/401/files into fork.

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -11,6 +11,7 @@ import types
 
 import torch.nn.functional as F
 from megatron.global_vars import set_retro_args, get_retro_args
+from megatron.model.enums import PositionEmbeddingType
 from tools.retro.utils import get_args_path as get_retro_args_path
 
 from megatron.core.transformer import TransformerConfig
@@ -242,8 +243,8 @@ def validate_args(args, defaults={}):
         args.num_layers = args.encoder_num_layers
 
     # Check required arguments.
-    required_args = ['num_layers', 'hidden_size', 'num_attention_heads',
-                     'max_position_embeddings']
+    required_args = ['num_layers', 'hidden_size', 'num_attention_heads']
+
     for req_arg in required_args:
         _check_arg_is_not_none(args, req_arg)
 
@@ -270,10 +271,13 @@ def validate_args(args, defaults={}):
         assert args.encoder_seq_length is not None
         args.seq_length = args.encoder_seq_length
 
-    if args.seq_length is not None:
-        assert args.max_position_embeddings >= args.seq_length
-    if args.decoder_seq_length is not None:
-        assert args.max_position_embeddings >= args.decoder_seq_length
+    if args.add_position_embedding:
+        assert args.max_position_embeddings is not None
+        if args.seq_length is not None:
+            assert args.max_position_embeddings >= args.seq_length
+        if args.decoder_seq_length is not None:
+            assert args.max_position_embeddings >= args.decoder_seq_length
+
     if args.lr is not None:
         assert args.min_lr <= args.lr
     if args.save is not None:
@@ -371,13 +375,13 @@ def validate_args(args, defaults={}):
                 set_retro_args(retro_args)
 
     # Legacy RoPE arguments
-    if args.use_rotary_position_embeddings:
-        args.position_embedding_type = 'rope'
+    #if args.use_rotary_position_embeddings:
+    #    args.position_embedding_type = 'rope'
 
     # Would just need to add 'NoPE' as a position_embedding_type to support this, but for now
     # don't allow it to keep things simple
-    if not args.add_position_embedding and args.position_embedding_type != 'rope':
-        raise RuntimeError('--no-position-embedding is deprecated, use --position-embedding-type')
+    #if not args.add_position_embedding and args.position_embedding_type != 'rope':
+    #    raise RuntimeError('--no-position-embedding is deprecated, use --position-embedding-type')
 
     # Print arguments.
     _print_args("arguments", args)
@@ -548,12 +552,14 @@ def _add_network_size_args(parser):
     group.add_argument('--max-position-embeddings', type=int, default=None,
                        help='Maximum number of position embeddings to use. '
                        'This is the size of position embedding.')
-    group.add_argument('--position-embedding-type', type=str, default='learned_absolute',
-                       choices=['learned_absolute', 'rope'],
-                       help='Position embedding type.')
-    group.add_argument('--use-rotary-position-embeddings', action='store_true',
-                       help='Use rotary positional embeddings or not. '
-                       'Deprecated: use --position-embedding-type')
+    group.add_argument('--position-embedding-type',
+                       type=lambda x: PositionEmbeddingType[x],
+                       choices=list(PositionEmbeddingType),
+                       default=PositionEmbeddingType.none,
+                       help='Define position embedding type, which is added '
+                       'in addition to the learned embedding'
+                       '("none" | "alibi" | "rotary"). '
+                       '"none" by default.)')
     group.add_argument('--rotary-percent', type=float, default=1.0,
                        help='Percent of rotary dimension to use, default 100%')
     group.add_argument('--no-position-embedding',

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -11,6 +11,7 @@ import torch
 
 from megatron import update_num_microbatches
 from megatron.core import mpu, tensor_parallel
+from megatron.model.enums import PositionEmbeddingType
 from .global_vars import get_args
 from .utils import (unwrap_model,
                     print_rank_0)
@@ -56,8 +57,10 @@ def check_checkpoint_args(checkpoint_args):
     _compare('hidden_size')
     _compare('num_attention_heads')
     _compare('add_position_embedding', default=True)
-    if args.vocab_file:
+    # With ALiBi, `max_position_embeddings` can be changed.
+    if args.position_embedding_type != PositionEmbeddingType.alibi:
         _compare('max_position_embeddings')
+    if args.vocab_file:
         _compare('make_vocab_size_divisible_by')
         _compare('padded_vocab_size')
         _compare('tokenizer_type')
@@ -474,7 +477,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
     _set_arg('max_position_embeddings')
     _set_arg('position_embedding_type', force=True)
     _set_arg('add_position_embedding', force=True)
-    _set_arg('use_rotary_position_embeddings', force=True)
+    _set_arg('position_embedding_type', force=True)
     _set_arg('rotary_percent', force=True)
     _set_arg('add_bias_linear', force=True)
     _set_arg('swiglu', force=True)

--- a/megatron/model/enums.py
+++ b/megatron/model/enums.py
@@ -17,5 +17,10 @@ class AttnMaskType(enum.Enum):
     padding = 1
     causal = 2
 
+class PositionEmbeddingType(enum.Enum):
+    none = 1
+    alibi = 2
+    rotary = 3
+
 # For backward compatibility with old model checkpoints
 from megatron.core.enums import ModelType

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -9,8 +9,7 @@ from megatron import get_args
 from megatron.core import mpu, tensor_parallel
 from megatron.core.enums import ModelType
 from megatron.core.models.common.rotary_pos_embedding import RotaryEmbedding
-
-from .enums import AttnMaskType, LayerType
+from .enums import AttnMaskType, LayerType, PositionEmbeddingType
 from .module import MegatronModule
 from .transformer import ParallelTransformer
 from .utils import get_linear_layer
@@ -371,9 +370,8 @@ class TransformerLanguageModel(MegatronModule):
             self._embedding_key = 'embedding'
 
         # Rotary positional embeddings
-        self.use_rotary_position_embeddings = \
-            args.position_embedding_type == 'rope'
-        if self.use_rotary_position_embeddings:
+        self.position_embedding_type = args.position_embedding_type
+        if args.position_embedding_type is PositionEmbeddingType.rotary:
             self.seq_length = args.seq_length
             rotary_dim = args.hidden_size // args.num_attention_heads \
                 if args.kv_channels is None else args.kv_channels
@@ -485,7 +483,7 @@ class TransformerLanguageModel(MegatronModule):
 
         # Rotary positional embeddings
         rotary_pos_emb = None
-        if self.use_rotary_position_embeddings:
+        if self.position_embedding_type is PositionEmbeddingType.rotary:
             if inference_params is not None:
                 rotary_pos_emb = \
                     self.rotary_pos_emb(inference_params.max_sequence_len)

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -13,7 +13,12 @@ from .module import MegatronModule
 from megatron.core import mpu, tensor_parallel
 from megatron.core.enums import ModelType
 from megatron.model import LayerNorm
-from megatron.model.enums import AttnMaskType, LayerType, AttnType
+from megatron.model.enums import (
+    AttnMaskType,
+    AttnType,
+    LayerType,
+    PositionEmbeddingType,
+)
 from megatron.model.fused_softmax import FusedScaleMaskSoftmax
 from megatron.model.fused_bias_gelu import bias_gelu_impl
 from megatron.core.models.common.rotary_pos_embedding import apply_rotary_pos_emb
@@ -241,7 +246,7 @@ class CoreAttention(MegatronModule):
         self.attention_dropout = torch.nn.Dropout(config.attention_dropout)
 
     def forward(self, query_layer, key_layer,
-                value_layer, attention_mask):
+                value_layer, attention_mask, alibi=None):
 
         # ===================================
         # Raw attention scores. [b, np, s, s]
@@ -260,17 +265,34 @@ class CoreAttention(MegatronModule):
         key_layer = key_layer.view(output_size[3],
                                    output_size[0] * output_size[1], -1)
 
-        # preallocting input tensor: [b * np, sq, sk]
-        matmul_input_buffer = mpu.get_global_memory_buffer().get_tensor(
-            (output_size[0]*output_size[1], output_size[2], output_size[3]),
-            query_layer.dtype, "mpu")
-
         # Raw attention scores. [b * np, sq, sk]
-        matmul_result = torch.baddbmm(
-            matmul_input_buffer,
-            query_layer.transpose(0, 1),   # [b * np, sq, hn]
-            key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
-            beta=0.0, alpha=(1.0/self.norm_factor))
+        if alibi is None:
+            # preallocting input tensor: [b * np, sq, sk]
+            matmul_input_buffer = mpu.get_global_memory_buffer().get_tensor(
+                (output_size[0]*output_size[1],
+                 output_size[2],
+                 output_size[3]),
+                query_layer.dtype, "mpu")
+
+            matmul_result = torch.baddbmm(
+                matmul_input_buffer,
+                query_layer.transpose(0, 1),   # [b * np, sq, hn]
+                key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+                beta=0.0, alpha=(1.0/self.norm_factor))
+        else:
+            matmul_result = alibi[
+                :output_size[0]*output_size[1], :, :output_size[3]]
+
+            if self.apply_query_key_layer_scaling:
+                beta = 1.0 / self.layer_number
+            else:
+                beta = 1.0
+
+            matmul_result = torch.baddbmm(
+                matmul_result,
+                query_layer.transpose(0, 1),  # [b * np, sq, hn]
+                key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+                beta=beta, alpha=(1.0 / self.norm_factor))
 
         # change view to [b, np, sq, sk]
         attention_scores = matmul_result.view(*output_size)
@@ -481,15 +503,18 @@ class ParallelAttention(MegatronModule):
 
     def _checkpointed_attention_forward(self, query_layer, key_layer,
                                         value_layer, attention_mask,
-                                        rotary_pos_emb=None):
+                                        rotary_pos_emb=None,
+                                        alibi=None):
         """Forward method with activation checkpointing."""
         def custom_forward(*inputs):
             query_layer = inputs[0]
             key_layer = inputs[1]
             value_layer = inputs[2]
             attention_mask = inputs[3]
+            alibi = inputs[6]
             output_ = self.core_attention(query_layer, key_layer,
-                                          value_layer, attention_mask)
+                                          value_layer, attention_mask,
+                                          alibi=alibi)
             return output_
 
         q_pos_emb, k_pos_emb = (None, None) if rotary_pos_emb is None \
@@ -498,7 +523,7 @@ class ParallelAttention(MegatronModule):
         hidden_states = tensor_parallel.checkpoint(
             custom_forward,
             False, query_layer, key_layer, value_layer, attention_mask,
-            q_pos_emb, k_pos_emb)
+            q_pos_emb, k_pos_emb, alibi)
 
         return hidden_states
 
@@ -513,7 +538,7 @@ class ParallelAttention(MegatronModule):
 
     def forward(self, hidden_states, attention_mask,
                 encoder_output=None, inference_params=None,
-                rotary_pos_emb=None):
+                rotary_pos_emb=None, alibi=None):
         # hidden_states: [sq, b, h]
 
         # =================================================
@@ -642,10 +667,12 @@ class ParallelAttention(MegatronModule):
         if not self.use_flash_attn:
             if self.checkpoint_core_attention:
                 context_layer = self._checkpointed_attention_forward(
-                    query_layer, key_layer, value_layer, attention_mask)
+                    query_layer, key_layer, value_layer, attention_mask,
+                    alibi=alibi)
             else:
                 context_layer = self.core_attention(
-                    query_layer, key_layer, value_layer, attention_mask)
+                    query_layer, key_layer, value_layer, attention_mask,
+                    alibi=alibi)
         else:
             q, k, v = [rearrange(x, 's b ... -> b s ...').contiguous()
                        for x in (query_layer, key_layer, value_layer)]
@@ -768,6 +795,22 @@ class ParallelTransformerLayer(MegatronModule):
             self.mlp = SwitchMLP(config)
         else:
             self.mlp = ParallelMLP(config)
+
+        # ALiBi
+        if args.position_embedding_type == PositionEmbeddingType.alibi:
+            assert not args.use_flash_attn, \
+                'ALiBi does not work with FlashAttention currently'
+            self.alibi = self._build_alibi_tensor(
+                args.seq_length,
+                args.num_attention_heads,
+                args.micro_batch_size,
+            ).to(torch.cuda.current_device())
+            if args.params_dtype is torch.float16:
+                self.alibi = self.alibi.to(torch.float16)
+            elif args.params_dtype is torch.bfloat16:
+                self.alibi = self.alibi.to(torch.bfloat16)
+        else:
+            self.alibi = None
 
         # Set bias+dropout+add fusion grad_enable execution handler.
         TORCH_MAJOR = int(torch.__version__.split('.')[0])
@@ -1022,7 +1065,8 @@ class ParallelTransformerLayer(MegatronModule):
                 layernorm_output,
                 attention_mask,
                 inference_params=inference_params,
-                rotary_pos_emb=rotary_pos_emb)
+                rotary_pos_emb=rotary_pos_emb,
+                alibi=self.alibi)
 
         # Residual connection.
         if self.apply_residual_connection_post_layernorm:
@@ -1134,6 +1178,47 @@ class ParallelTransformerLayer(MegatronModule):
             return output, retriever_output
         else:
             return output
+
+    @staticmethod
+    def _build_alibi_tensor(max_seq_len, num_attention_heads, batch_size):
+        # Copied from bigscience-workshop/Megatron-DeepSpeed
+        # Based on https://github.com/ofirpress/attention_with_linear_biases/blob/a35aaca144e0eb6b789dfcb46784c4b8e31b7983/fairseq/models/transformer.py#L742
+        """Returns tensor shaped
+        (batch_size * num_attention_heads, 1, max_seq_len).
+        """
+
+        def get_slopes(n):
+            def get_slopes_power_of_2(n):
+                start = (2 ** (-2 ** -(math.log2(n) - 3)))
+                ratio = start
+                return [start * ratio ** i for i in range(n)]
+
+            if math.log2(n).is_integer():
+                return get_slopes_power_of_2(n)
+            else:
+                closest_power_of_2 = 2 ** math.floor(math.log2(n))
+                return (
+                    get_slopes_power_of_2(closest_power_of_2)
+                    + get_slopes(
+                        2 * closest_power_of_2,
+                    )[0::2][:n - closest_power_of_2]
+                )
+
+        slopes = torch.Tensor(get_slopes(num_attention_heads))
+        alibi = (
+            slopes.unsqueeze(1).unsqueeze(1)
+            * torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(
+                num_attention_heads, -1, -1)
+        )
+
+        # Select the part of the tensor that corresponds to our tensor
+        # parallel index.
+        tp_world_size = mpu.get_tensor_model_parallel_world_size()
+        tp_index = mpu.get_tensor_model_parallel_rank()
+        alibi = alibi.reshape((tp_world_size, -1, *alibi.shape[1:]))[tp_index]
+
+        alibi = alibi.repeat(batch_size, 1, 1)
+        return alibi
 
 
 class NoopTransformerLayer(MegatronModule):

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -30,6 +30,7 @@ def _load_checkpoint(queue, args):
         from megatron.global_vars import set_args, set_global_variables
         from megatron.checkpointing import load_args_from_checkpoint, load_checkpoint
         from megatron.model import module
+        from megatron.model.enums import PositionEmbeddingType
         from megatron.core import mpu
         from megatron.core.enums import ModelType
         from megatron import fused_kernels
@@ -80,7 +81,7 @@ def _load_checkpoint(queue, args):
     check_for_arg('seq_length')
     check_for_arg('num_attention_heads')
     check_for_arg('max_position_embeddings')
-    check_for_arg('position_embedding_type')
+    check_for_arg('position_embedding_type', PositionEmbeddingType.absolute)
     check_for_arg('tokenizer_type')
     check_for_arg('iteration')
     check_for_arg('bert_binary_head')


### PR DESCRIPTION
Porting alibi implementation from:
https://github.com/NVIDIA/Megatron-LM/pull/401/files 
into fork.

Verified it worked both with alibi enabled and disabled on code parrot dataset example.

Without Alibi:
torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
    --tensor-model-parallel-size 2 \
    --pipeline-model-parallel-size 2 \
    --empty-unused-memory-level 2 \
    --sequence-parallel \
    --recompute-granularity selective \
    --recompute-num-layers 1 \
    --use-distributed-optimizer \
    --use-cpu-initialization \
    $GPT_ARGS \
    $DATA_ARGS \
    $OUTPUT_ARGS \
    --save $CHECKPOINT_PATH \
    --load $CHECKPOINT_PATH

With Alibi:
torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
    --tensor-model-parallel-size 2 \
    --pipeline-model-parallel-size 2 \
    --empty-unused-memory-level 2 \
    --sequence-parallel \
    --recompute-granularity selective \
    --recompute-num-layers 1 \
    --use-distributed-optimizer \
    --use-cpu-initialization \
    --position-embedding-type alibi \
    $GPT_ARGS \
    $DATA_ARGS \
    $OUTPUT_ARGS \
    --save $CHECKPOINT_PATH \
    --load $CHECKPOINT_PATH
